### PR TITLE
[Github Action] Fix the setting of OS_PROJECTS

### DIFF
--- a/.github/workflows/build-and-push-rag-content.yaml
+++ b/.github/workflows/build-and-push-rag-content.yaml
@@ -46,7 +46,7 @@ jobs:
           registry: registry.redhat.io
 
       - name: Build only partial rag-content when running in the check pipeline
-        if: github.event_name != 'schedule' || github.event_name != 'push'
+        if: github.event_name != 'schedule' && github.event_name != 'push'
         run: |
           echo OS_PROJECTS="nova" >> $GITHUB_ENV
 


### PR DESCRIPTION
Currently, we execute the partial image build when event_name is not 'push' OR 'schedule' when we should be building a partial image build if event_name is not 'push' AND 'schedule'.